### PR TITLE
Add ability to specify a path on Ingress objects for Jira and Confluence helm charts.

### DIFF
--- a/confluence/templates/ingress.yaml
+++ b/confluence/templates/ingress.yaml
@@ -17,7 +17,11 @@ spec:
   - host: {{ .Values.Ingress.Host }}
     http:
       paths:
+      {{- if .Values.Ingress.Path }}
+      - path: {{ .Values.Ingress.Path }}
+      {{- else }}
       - path: /
+      {{- end }}
         backend:
           serviceName: {{ .Release.Name }}
           servicePort: {{ .Values.Ingress.ServicePort }}

--- a/confluence/values.yaml
+++ b/confluence/values.yaml
@@ -97,7 +97,7 @@ Ingress:
   # Annotations:
   #   - key: value
   # Optional: Define a path to use in the ingress
-  Path: /confluence
+  # Path: /confluence
 
 PodDisruption:
   Enabled: false

--- a/confluence/values.yaml
+++ b/confluence/values.yaml
@@ -96,6 +96,8 @@ Ingress:
   ServicePort: 8090
   # Annotations:
   #   - key: value
+  # Optional: Define a path to use in the ingress
+  Path: /confluence
 
 PodDisruption:
   Enabled: false

--- a/jira/templates/ingress.yaml
+++ b/jira/templates/ingress.yaml
@@ -10,8 +10,12 @@ spec:
   rules:
   - host: {{ .Values.Ingress.Host }}
     http:
-      paths:
+      paths: 
+      {{- if .Values.Ingress.Path }}
+      - path: {{ .Values.Ingress.Path }}
+      {{- else }}
       - path: /
+      {{- end }}
         backend:
           serviceName: {{ .Release.Name }}
           servicePort: {{ .Values.Ingress.ServicePort }}

--- a/jira/values.yaml
+++ b/jira/values.yaml
@@ -113,6 +113,8 @@ Ingress:
   Enabled: true
   Host: jira.example.com
   ServicePort: 8080
+  # Optional: Define a path to use in the ingress
+  # Path: /jira
 
 # to add promethues annotations
 PrometheusMetrics:


### PR DESCRIPTION
Adding the ability to specify a path to the ingress templates for both Jira and Confluence. The templates and were changed in such a way as to be backwards compatible while allowing the ability to specify a path if desired.