### PR TITLE
TLS support for Jira, Confluence and BitBucket.

### DIFF
--- a/bitbucket/Chart.yaml
+++ b/bitbucket/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Bitbucket Server Helm chart for Kubernetes
 name: bitbucket
-version: 1.0.2
+version: 1.1.0
 home: https://praqma.com/
 maintainers:
   - name: "@sami-alajrami"

--- a/bitbucket/templates/ingress.yaml
+++ b/bitbucket/templates/ingress.yaml
@@ -6,12 +6,10 @@ metadata:
   name: {{ .Release.Name }}
   labels:
     app: {{ .Release.Name }}
-  {{- if .Values.Ingress.Annotations }}
+{{- if .Values.Ingress.Annotations }}
   annotations:
-  {{- range $key, $value := .Values.Ingress.Annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
-  {{- end }}  
+{{ toYaml .Values.Ingress.Annotations | indent 4 }}
+{{- end }}
 spec:
   rules:
   - host: {{ .Values.Ingress.Host }}

--- a/bitbucket/templates/ingress.yaml
+++ b/bitbucket/templates/ingress.yaml
@@ -6,6 +6,12 @@ metadata:
   name: {{ .Release.Name }}
   labels:
     app: {{ .Release.Name }}
+  {{- if .Values.Ingress.Annotations }}
+  annotations:
+  {{- range $key, $value := .Values.Ingress.Annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}  
 spec:
   rules:
   - host: {{ .Values.Ingress.Host }}
@@ -15,4 +21,10 @@ spec:
         backend:
           serviceName: {{ .Release.Name }}
           servicePort: {{ .Values.Ingress.ServicePort }}
+  {{- if .Values.Ingress.Tls.Enabled }}
+  tls:
+  - secretName: {{ .Values.Ingress.Tls.SecretName }}
+    hosts:
+    - {{ .Values.Ingress.Host }}
+  {{- end }}
 {{- end }}

--- a/bitbucket/values.yaml
+++ b/bitbucket/values.yaml
@@ -145,7 +145,11 @@ Ingress:
   Enabled: true
   Host: bitbucket.example.com
   ServicePort: 7990
-
+  # Annotations:
+  #   ingress.kubernetes.io/force-ssl-redirect: "true"
+  Tls:
+    Enabled: False
+    SecretName: ""
 
 # to add promethues annotations
 PrometheusMetrics:

--- a/confluence/Chart.yaml
+++ b/confluence/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Confluence Server Helm chart for Kubernetes
 name: confluence
-version: 1.0.2
+version: 1.1.0
 home: https://praqma.com/
 maintainers:
   - name: "@sami-alajrami"

--- a/confluence/templates/ingress.yaml
+++ b/confluence/templates/ingress.yaml
@@ -6,12 +6,10 @@ metadata:
   name: {{ .Release.Name }}
   labels:
     app: {{ .Release.Name }}
-  {{- if .Values.Ingress.Annotations }}
+{{- if .Values.Ingress.Annotations }}
   annotations:
-  {{- range $key, $value := .Values.Ingress.Annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
-  {{- end }}  
+{{ toYaml .Values.Ingress.Annotations | indent 4 }}
+{{- end }}
 spec:
   rules:
   - host: {{ .Values.Ingress.Host }}

--- a/confluence/templates/ingress.yaml
+++ b/confluence/templates/ingress.yaml
@@ -21,4 +21,10 @@ spec:
         backend:
           serviceName: {{ .Release.Name }}
           servicePort: {{ .Values.Ingress.ServicePort }}
+  {{- if .Values.Ingress.Tls.Enabled }}
+  tls:
+  - secretName: {{ .Values.Ingress.Tls.SecretName }}
+    hosts:
+    - {{ .Values.Ingress.Host }}
+  {{- end }}
 {{- end }}

--- a/confluence/values.yaml
+++ b/confluence/values.yaml
@@ -95,7 +95,10 @@ Ingress:
   Host: confluence.example.com
   ServicePort: 8090
   # Annotations:
-  #   - key: value
+  #   ingress.kubernetes.io/force-ssl-redirect: "true"
+  Tls:
+    Enabled: False
+    SecretName: ""
 
 PodDisruption:
   Enabled: false

--- a/jira/Chart.yaml
+++ b/jira/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Jira-Server Helm chart for Kubernetes
 name: jira
-version: 1.0.2
+version: 1.1.0
 home: https://praqma.com/
 maintainers:
   - name: "@sami-alajrami"

--- a/jira/templates/ingress.yaml
+++ b/jira/templates/ingress.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ .Release.Name }}
   labels:
     app: {{ .Release.Name }}
+{{- if .Values.Ingress.Annotations }}
+  annotations:
+{{ toYaml .Values.Ingress.Annotations | indent 4 }}
+{{- end }}
 spec:
   rules:
   - host: {{ .Values.Ingress.Host }}
@@ -15,4 +19,10 @@ spec:
         backend:
           serviceName: {{ .Release.Name }}
           servicePort: {{ .Values.Ingress.ServicePort }}
+  {{- if .Values.Ingress.Tls.Enabled }}
+  tls:
+  - secretName: {{ .Values.Ingress.Tls.SecretName }}
+    hosts:
+    - {{ .Values.Ingress.Host }}
+  {{- end }}
 {{- end }}

--- a/jira/values.yaml
+++ b/jira/values.yaml
@@ -113,6 +113,11 @@ Ingress:
   Enabled: true
   Host: jira.example.com
   ServicePort: 8080
+  # Annotations:
+  #   ingress.kubernetes.io/force-ssl-redirect: "true"
+  Tls:
+    Enabled: False
+    SecretName: ""
 
 # to add promethues annotations
 PrometheusMetrics:


### PR DESCRIPTION
Also adds support for ingress annotations for Jira and BitBucket. Bumps all chart minor version as this is a backward compatible addition (defaults off).
