### PR TITLE
Make SSH service more self-contained and configurable (service type, node port, load balancer IP, annotations)

### DIFF
--- a/bitbucket/Chart.yaml
+++ b/bitbucket/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Bitbucket Server Helm chart for Kubernetes
 name: bitbucket
-version: 1.1.0
+version: 2.0.0
 home: https://praqma.com/
 maintainers:
   - name: "@sami-alajrami"

--- a/bitbucket/templates/ssh-service.yaml
+++ b/bitbucket/templates/ssh-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.Service.SshNodePortService }}
+{{- if .Values.SshService.Enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,7 +8,7 @@ metadata:
     serviceType: ssh
 
   annotations:
-  {{- range $key, $value := .Values.Service.Annotations }}
+  {{- range $key, $value := .Values.SshService.Annotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 
@@ -19,9 +19,14 @@ spec:
       name: bitbucket-ssh-port
       targetPort: 7999
       protocol: TCP
+      {{- if and (eq .Values.SshService.Type "NodePort") .Values.SshService.NodePort }}
+      nodePort: {{ .Values.SshService.NodePort }}
+      {{- end }}
 
-
-  type: NodePort
+  type: {{ .Values.SshService.Type }}
+  {{- if and (eq .Values.SshService.Type "LoadBalancer") .Values.SshService.LoadBalancerIP }}
+  loadBalancerIP: {{ .Values.SshService.LoadBalancerIP }}
+  {{- end }}
 
   selector:
     app: {{ .Release.Name }}

--- a/bitbucket/values.yaml
+++ b/bitbucket/values.yaml
@@ -132,9 +132,16 @@ PodDisruption:
   Enabled: false
   MinAvailable: 1
 
+SshService:
+  Enabled: false
+  Type: NodePort
+  # NodePort: 31000
+  # LoadBalancerIP: "1.2.3.4"
+  # Annotations:
+  #   key: value
+
 Service:
   #Name: "bitbucket"
-  SshNodePortService: false
   Type: ClusterIP
   Port: 7990
   Protocol: TCP


### PR DESCRIPTION
Updated chart version to 2.0.0 because the split of the ssh service into its own section in values.yaml is not backward compatible (e.g. it now has its own annotations).