### PR TITLE
rbac based on release name and not hard coded to jira

### DIFF
--- a/jira/templates/clusterrole.yaml
+++ b/jira/templates/clusterrole.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: jira
+  name: {{ .Release.Name }}
 rules:
   - apiGroups:
       - ""

--- a/jira/templates/clusterrolebindings.yaml
+++ b/jira/templates/clusterrolebindings.yaml
@@ -2,13 +2,13 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: jira
+  name: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: jira
+  name: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: jira
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/jira/templates/serviceaccount.yaml
+++ b/jira/templates/serviceaccount.yaml
@@ -2,5 +2,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: jira
+  name: {{ .Release.Name }}
 {{- end }}

--- a/jira/templates/statefulset.yaml
+++ b/jira/templates/statefulset.yaml
@@ -24,7 +24,7 @@ spec:
         app: {{ .Release.Name }}
     spec:
       {{- if .Values.RBAC.Enabled }}
-      serviceAccountName: jira
+      serviceAccountName: {{ .Release.Name }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.TerminationGracePeriodSeconds | default 50 }}
       containers:


### PR DESCRIPTION
Changed the hard coded RBAC manifests to use release name instead of 'jira'. When using the same chart to install multiple releases (eg. jira-prod, jira-dev, jira-staging) the RBAC manifests would clash since they would all have the same name