### PR TITLE
Updated api version for deprecated versions

### DIFF
--- a/jira/templates/clusterrole.yaml
+++ b/jira/templates/clusterrole.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.RBAC.Enabled }}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: jira
 rules:

--- a/jira/templates/clusterrolebindings.yaml
+++ b/jira/templates/clusterrolebindings.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.RBAC.Enabled }}
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: jira
 roleRef:

--- a/jira/templates/ingress.yaml
+++ b/jira/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.Ingress.Enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 kind: Ingress
 metadata:
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Updated api versions for deprecated ones since the chart cannot be installed on Kubernetes 1.20 cluster version